### PR TITLE
use mutator observer

### DIFF
--- a/relative.js
+++ b/relative.js
@@ -16,10 +16,15 @@ function setRelativeLineNumber() {
     }
 }
 
-document.addEventListener('click', setRelativeLineNumber)
-document.addEventListener('keyup', (e) => {
-    const key = e.key
-    if (key === 'j' || key == 'k' || key == 'd' || key == 'o' || key == 'O' || key == 'g' || key == 'G') {
-        setRelativeLineNumber()
+const observer = new MutationObserver((mutationList) => {
+    for (const mutation of mutationList) {
+        if (mutation.type === 'childList') {
+            setRelativeLineNumber()
+        }
     }
+})
+
+observer.observe(document.getElementById('editor'), {
+    childList: true,
+    subtree: true
 })


### PR DESCRIPTION
This change use MutatorObserver instead of keyup. This will handle every actions that cause line numbers to change. It also fix the issue with the current line number appear brifely before deleted.